### PR TITLE
style: add "default" option for SCSS variables

### DIFF
--- a/scss/smartphoto.scss
+++ b/scss/smartphoto.scss
@@ -1,7 +1,7 @@
-$animation-speed: .3s;
-$animation-function: ease-out;
-$backdrop-color: rgba(0, 0, 0, 1);
-$header-color: rgba(0, 0, 0, .2);
+$animation-speed: .3s !default;
+$animation-function: ease-out !default;
+$backdrop-color: rgba(0, 0, 0, 1) !default;
+$header-color: rgba(0, 0, 0, .2) !default;
 
 @keyframes smartphoto {
   from {


### PR DESCRIPTION
Now SCSS variables can be overriden, for example:

```scss
$animation-speed: .2s;
$animation-function: ease-in-out;
$backdrop-color: rgba(255, 255, 255, 1);
$header-color: rgba(45, 0, 45, .2);

@import "node_modules/smartphoto/scss/smartphoto.scss";
```